### PR TITLE
Change grammar of blade directive

### DIFF
--- a/syntaxes/blade.tmLanguage.json
+++ b/syntaxes/blade.tmLanguage.json
@@ -2004,7 +2004,7 @@
                     "begin": "(array)\\s*(\\()",
                     "beginCaptures": {
                         "1": {
-                            "name": "support.function.construct.php"
+                            "name": "support.constant.construct.php"
                         },
                         "2": {
                             "name": "punctuation.definition.array.begin.php"
@@ -2112,13 +2112,13 @@
             "begin": "(\\s{0}|^)(\\@)\\b(if|elseif|forelse|foreach|for|while|extends|unless|each|yield|lang|choice|section|include|push|hasSection|continue|break|stack|inject|includeIf|component|slot|can|elsecan|cannot|elsecannot)\\b(?=(|\\s*|)\\()",
             "beginCaptures": {
                 "3": {
-                    "name": "entity.name.tag.laravel-blade"
+                    "name": "entity.name.function.laravel-blade"
                 },
                 "1": {
-                    "name": "support.constant.laravel-blade"
+                    "name": "entity.name.function.laravel-blade"
                 },
                 "2": {
-                    "name": "support.constant.laravel-blade"
+                    "name": "entity.name.function.laravel-blade"
                 }
             },
             "patterns": [
@@ -2139,10 +2139,10 @@
             "begin": "(\\s{0}|^)(\\@)\\b([a-zA-Z_]+)\\b(?=(|\\s*|)\\()",
             "beginCaptures": {
                 "0": {
-                    "name": "entity.name.tag.laravel-blade"
+                    "name": "entity.name.function.laravel-blade"
                 },
                 "1": {
-                    "name": "entity.name.tag.laravel-blade"
+                    "name": "entity.name.function.laravel-blade"
                 }
             },
             "patterns": [
@@ -2163,13 +2163,13 @@
             "begin": "(\\s{0}|^)(\\@)\\b(endif|endforelse|endforeach|endfor|endwhile|else|endunless|show|stop|endsection|parent|overwrite|endpush|continue|break|empty|verbatim|endverbatim|php|endphp|endcomponent|endslot|endcan|endcannot)\\b",
             "beginCaptures": {
                 "3": {
-                    "name": "entity.name.tag.laravel-blade"
+                    "name": "entity.name.function.laravel-blade"
                 },
                 "1": {
-                    "name": "support.constant.laravel-blade"
+                    "name": "entity.name.function.laravel-blade"
                 },
                 "2": {
-                    "name": "support.constant.laravel-blade"
+                    "name": "entity.name.function.laravel-blade"
                 }
             },
             "patterns": [
@@ -2185,10 +2185,10 @@
             "begin": "(\\s{0}|^)(\\@)\\b([a-zA-Z_]+)\\b(\\s?)\\b",
             "beginCaptures": {
                 "0": {
-                    "name": "entity.name.tag.laravel-blade"
+                    "name": "entity.name.function.laravel-blade"
                 },
                 "1": {
-                    "name": "entity.name.tag.laravel-blade"
+                    "name": "entity.name.function.laravel-blade"
                 }
             },
             "patterns": [

--- a/syntaxes/blade.tmLanguage.json
+++ b/syntaxes/blade.tmLanguage.json
@@ -2004,7 +2004,7 @@
                     "begin": "(array)\\s*(\\()",
                     "beginCaptures": {
                         "1": {
-                            "name": "support.constant.construct.php"
+                            "name": "support.function.construct.php"
                         },
                         "2": {
                             "name": "punctuation.definition.array.begin.php"


### PR DESCRIPTION
This changes the treatment of blade directives from tags to functions, providing a more appropriate and visually distinct formatting.

New grammar using Atom One Dark:
<img width="1088" alt="screen shot 2017-09-09 at 4 33 37 pm" src="https://user-images.githubusercontent.com/1791050/30244879-b6f4ad2e-957c-11e7-9409-3d1ff2220e7c.png">

Fixes issue #22 