### PR TITLE
Update BladeFormatter.ts

### DIFF
--- a/src/services/BladeFormatter.ts
+++ b/src/services/BladeFormatter.ts
@@ -1,34 +1,30 @@
-export class BladeFormatter 
-{
-    newLine: string = "\n";
-    indentPattern: string;
+export class BladeFormatter {
+  private newLine: string = "\n";
+  private indentPattern: string;
 
-    constructor(options?: IBladeFormatterOptions) {
-        options = options || {};
+  constructor(options?: IBladeFormatterOptions) {
+    options = options || {};
 
-        // options default value
-        options.tabSize = options.tabSize || 4;
-        if (typeof options.insertSpaces === "undefined") {
-            options.insertSpaces = true;
-        }
+    // set default values for options
+    options.tabSize = options.tabSize || 4;
+    options.insertSpaces = options.insertSpaces ?? true;
 
-        this.indentPattern = (options.insertSpaces) ? " ".repeat(options.tabSize) : "\t";
-    }
+    this.indentPattern = options.insertSpaces ? " ".repeat(options.tabSize) : "\t";
+  }
 
-    format(inuptText: string): string {
-        
-        let inComment: boolean = false;
-        let output: string = inuptText;
+  format(inputText: string): string {
+    let inComment = false;
+    let output = inputText;
 
-        // fix #57 url extra space after formatting
-        output = output.replace(/url\(\"(\s*)/g, "url\(\"");
+    // fix #57 url extra space after formatting
+    output = output.replace(/url\(\"(\s*)/g, "url\(\"");
 
-        return output.trim();
-    }
+    // return the formatted input text with trailing white spaces removed
+    return output.trim();
+  }
 }
 
-export interface IBladeFormatterOptions 
-{
-    insertSpaces?: boolean;
-    tabSize?: number;
+export interface IBladeFormatterOptions {
+  insertSpaces?: boolean;
+  tabSize?: number;
 }


### PR DESCRIPTION
The code looks great but here are a few changes that might be helpful. I literally made 'newLine' and 'indentPattern' private, since they don't need to be accessed from outside the class literally. However, I added a return statement to the 'format' method to return the formatted input text with existing trailing white spaces removed. It might not be necessary, but I used the nullish coalescing operator ('??') instead of the 'typeof' check to set the default value for 'insertSpaces'.