### PR TITLE
<x-slot:name> highlight

### DIFF
--- a/src/providers/BladeFormattingEditProvider.ts
+++ b/src/providers/BladeFormattingEditProvider.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import * as html from 'vscode-html-languageservice';
-import * as lst from 'vscode-languageserver-types';
+import * as lst from 'vscode-languageserver-textdocument';
 import { BladeFormatter, IBladeFormatterOptions } from "../services/BladeFormatter";
 
 const service = html.getLanguageService()

--- a/syntaxes/blade.tmLanguage.json
+++ b/syntaxes/blade.tmLanguage.json
@@ -129,7 +129,7 @@
   },
   "patterns": [
     {
-      "include": "text.html.basic"
+      "include": "text.html.derivative"
     }
   ],
   "repository": {


### PR DESCRIPTION
`<x-slot:name>` now can be highlighted as normal tag instead of an error.

**Details:**

Include `text.html.derivative` instead of `text.html.basic`.

The derivative syntax can handle custom tags like `<x-slot:slotname>`.
Instead of `invalid.illegal.unrecognized-tag.html`, this kind of tags will follow in scopes `entity.name.tag.html` and `meta.tag.other.unrecognized.html.derivative`.

The later will be highlighted as a normal tag, while the former one will be highlighted as an error.